### PR TITLE
Update decoder.py

### DIFF
--- a/garmin_fit_sdk/decoder.py
+++ b/garmin_fit_sdk/decoder.py
@@ -14,8 +14,6 @@
 
 import copy
 
-from attrs import field
-
 from . import Accumulator, BitStream, CrcCalculator
 from . import fit as FIT
 from . import hr_mesg_utils, util

--- a/garmin_fit_sdk/decoder.py
+++ b/garmin_fit_sdk/decoder.py
@@ -14,7 +14,7 @@
 
 import copy
 
-from attr import field
+from attrs import field
 
 from . import Accumulator, BitStream, CrcCalculator
 from . import fit as FIT


### PR DESCRIPTION
hey, when I try to import Decoder it breaks because `field` doesn't exists in `attr` module, I believe it had to be `attrs` module, chears