### PR TITLE
developer_fields should use field_definition_number, not key

### DIFF
--- a/garmin_fit_sdk/decoder.py
+++ b/garmin_fit_sdk/decoder.py
@@ -290,7 +290,7 @@ class Decoder:
                 #NOTE possible point to scrub invalids????
 
                 if field_value is not None:
-                    developer_fields[field_profile['key']] = field_value
+                    developer_fields[field_profile['field_definition_number']] = field_value
 
         if mesg_def['global_mesg_num'] == Profile['mesg_num']['DEVELOPER_DATA_ID']:
             self.__add_developer_data_id_to_profile(message)


### PR DESCRIPTION
The message decoder handling of developer fields provides a separate dict for the developer fields found in a message.

This contains key value pairs like 'developer_fields': {0: nan, 1: 255}

Currently, the key is set with from the field_profile['key'], where 'key' appears to be an index into the array holding the definitions. 

`developer_fields[field_profile['key']] = field_value`

That has no use for adequately matching the fields to names via the field description messages. It is information that is only of interest internally to the Decoder class. The correct key should be the 'field_definition_number' which can be used to find the right developer field information from the previously seen field_description message.

`developer_fields[field_profile['field_definition_number']] = field_value`

Which for the above example would produce 'developer_fields': {1: nan, 2: 255}, which now matches the field_definition_number from the field_descriptions for the two developer fields.


