### PR TITLE
Avoid using depreciated datetime functionality

### DIFF
--- a/garmin_fit_sdk/util.py
+++ b/garmin_fit_sdk/util.py
@@ -12,13 +12,13 @@
 ############################################################################################
 
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 FIT_EPOCH_S = 631065600
 
 def convert_timestamp_to_datetime(timestamp):
     '''Takes a FIT datetime timestamp and converts it to a python datetime in utc'''
-    utc_datetime = datetime.utcfromtimestamp((timestamp if timestamp else 0) + FIT_EPOCH_S)
+    utc_datetime = datetime.fromtimestamp((timestamp if timestamp else 0) + FIT_EPOCH_S, UTC)
     return utc_datetime.replace(tzinfo=timezone.utc)
 
 def _convert_string(string):

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -8,7 +8,7 @@
 ###########################################################################################
 
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 from garmin_fit_sdk import Decoder, Stream, CrcCalculator
@@ -304,9 +304,9 @@ class TestDecoderRead():
     @pytest.mark.parametrize(
         "option_status,expected_value",
         [
-            (True, datetime.utcfromtimestamp(1000000000 + 631065600)),
+            (True, datetime.fromtimestamp(1000000000 + 631065600, UTC)),
             (False, 1000000000),
-            (None, datetime.utcfromtimestamp(1000000000 + 631065600))
+            (None, datetime.fromtimestamp(1000000000 + 631065600, UTC))
         ], ids=["Set to True", "Set to False", "Default Should Convert Timestamps"]
     )
     def test_convert_datetimes_to_python_datetimes(self, option_status, expected_value):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@
 ###########################################################################################
 
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 from garmin_fit_sdk import util
@@ -17,9 +17,9 @@ from garmin_fit_sdk import util
 @pytest.mark.parametrize(
     "given_timestamp,expected_datetime",
     [
-        (1029086357, datetime.utcfromtimestamp(1029086357 + 631065600)),
-        (0, datetime.utcfromtimestamp(631065600)),
-        (None, datetime.utcfromtimestamp(631065600)),
+        (1029086357, datetime.fromtimestamp(1029086357 + 631065600, UTC)),
+        (0, datetime.fromtimestamp(631065600, UTC)),
+        (None, datetime.fromtimestamp(631065600, UTC)),
     ], ids=["Regular timestamp", "0 timestamp defaults to FITEPOCH", "Null timestamp defaults to FITEPOCH"],
 )
 def test_convert_datetime(given_timestamp, expected_datetime):


### PR DESCRIPTION
In this pull request, we switch from using the depreciated `datetime.datetime.utcfromtimestamp` to `datetime.fromtimestamp(<timestamp>, datetime.UTC)`

This means running the unit tests no longer has warnings everywhere.