### PR TITLE
Use OIDC Publishing to PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,13 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
 
@@ -33,8 +35,5 @@ jobs:
         --outdir dist/
         .
 
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+    - name: Publish release distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f


### PR DESCRIPTION
- Pins the publishing action to the workshow SHA for better stability.

- Pins checkout and master actions to newer/more static versions.

- Gives workflow token permissions required for OIDC token exchange.